### PR TITLE
add json support as texture output format. tested with pixijs

### DIFF
--- a/PyTexturePacker/Utils.py
+++ b/PyTexturePacker/Utils.py
@@ -13,6 +13,8 @@ if sys.version_info.major > 2:
     xrange = range
 
 SUPPORTED_IMAGE_FORMAT = [".png", ".jpg", ".bmp"]
+ATLAS_FORMAT_PLIST = "plist"
+ATLAS_FORMAT_JSON = "json"
 
 
 def load_images_from_paths(image_path_list):
@@ -50,6 +52,44 @@ def load_images_from_dir(dir_path):
     return load_images_from_paths(image_rect_path)
 
 
+def get_atlas_data_ext(atlas_format):
+    """
+    get default file extension for selected type of atlas data file
+    :param atlas_format: atlas data file format
+    :return:
+    """
+    if atlas_format == ATLAS_FORMAT_PLIST:
+        return '.plist'
+    if atlas_format == ATLAS_FORMAT_JSON:
+        return '.json'
+
+
+def save_atlas_data(data_dict, file_path, atlas_format):
+    """
+    save a atlas data in selected format. plist or json supported
+    :param data_dict: dict data
+    :param file_path: file path to save
+    :param atlas_format: atlas data file format
+    :return:
+    """
+    if atlas_format == ATLAS_FORMAT_PLIST:
+        return save_plist(data_dict, file_path)
+    if atlas_format == ATLAS_FORMAT_JSON:
+        return save_json(data_dict, file_path)
+
+
+def save_json(data_dict, file_path):
+    """
+    save a dict as a json file
+    :param data_dict: dict data
+    :param file_path: json file path to save
+    :return:
+    """
+    import json
+    with open(file_path, 'w') as fp:
+        json.dump(data_dict, fp)
+
+
 def save_plist(data_dict, file_path):
     """
     save a dict as a plist file
@@ -70,7 +110,7 @@ def save_image(image, file_path):
     """
     save a Image as a file
     :param image: Image
-    :param file_name: file path to save
+    :param file_path: file path to save
     :return:
     """
     image.save(file_path)

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,11 @@ There are two uses for this:
 - Reduce flickering in some cases where sprites have to be put next to each other in the final program.
 - Check if sprite outlines are OK. E.g. if you want to use sprites to create tilemaps this allows you to see if there are semi-transparent pixels at the borders of the tiles.
 
+atlas_format
+-------
+Choose the texture config format that file will use. Available options "plist" or "json".
+The default texture config output format is "plist".
+
 Contribute
 ==========
 


### PR DESCRIPTION
Add support for json output format for atlas cofnig. That allows to use your library with web frameworks like pixi.js, phaser.js, etc.

The implementation may not support all feature, but in my current projects that works fine. I used before TexturePacker version 4+, but theirs CLI tools is uncomfortable. So with your lib I made better build script for my projects. Thank you.