### PR TITLE
Added support for CSVs, as well as callback functions as the atlas_format

### DIFF
--- a/PyTexturePacker/PackerInterface/AtlasInterface.py
+++ b/PyTexturePacker/PackerInterface/AtlasInterface.py
@@ -9,7 +9,7 @@ Description:
     AtlasInterface.py
 ----------------------------------------------------------------------------"""
 
-from ..Utils import ATLAS_FORMAT_PLIST, ATLAS_FORMAT_JSON
+from ..Utils import ATLAS_FORMAT_PLIST#, ATLAS_FORMAT_JSON
 
 MAX_RANK = 2 ** 32
 MAX_WIDTH = 1024 * 16
@@ -68,8 +68,7 @@ class AtlasInterface(object):
                         image_rect.source_box[0], image_rect.source_box[1], width, height),
                     sourceSize="{%d,%d}" % image_rect.source_size,
                 )
-
-            if atlas_format == ATLAS_FORMAT_JSON:
+            else:
                 frames[path] = dict(
                     frame=dict(x=image_rect.x, y=image_rect.y, w=width, h=height),
                     rotated=bool(image_rect.rotated),
@@ -88,8 +87,7 @@ class AtlasInterface(object):
                 realTextureFileName=texture_file_name,
                 size="{%d,%d}" % self.size,
             )
-
-        if atlas_format == ATLAS_FORMAT_JSON:
+        else:
             plist_data["meta"] = dict(
                 image=texture_file_name,
                 format="RGBA8888",

--- a/PyTexturePacker/PackerInterface/PackerInterface.py
+++ b/PyTexturePacker/PackerInterface/PackerInterface.py
@@ -34,7 +34,7 @@ class PackerInterface(object):
 
     def __init__(self, bg_color=0x00000000, texture_format=".png", max_width=4096, max_height=4096, enable_rotated=True,
                  force_square=False, border_padding=2, shape_padding=2, inner_padding=0, trim_mode=0,
-                 reduce_border_artifacts=False, extrude=0, atlas_format=Utils.ATLAS_FORMAT_PLIST):
+                 reduce_border_artifacts=False, extrude=0, atlas_format=Utils.ATLAS_FORMAT_PLIST, atlas_ext=None):
         """
         init a packer
         :param bg_color: background color of output image.
@@ -65,6 +65,7 @@ class PackerInterface(object):
         self.trim_mode = trim_mode
         self.reduce_border_artifacts = reduce_border_artifacts
         self.atlas_format = atlas_format
+        self.atlas_ext = atlas_ext
 
     @staticmethod
     def _calculate_area(image_rect_list, inner_padding):
@@ -194,7 +195,7 @@ class PackerInterface(object):
             if self.reduce_border_artifacts:
                 packed_image = Utils.alpha_bleeding(packed_image)
 
-            atlas_data_ext = Utils.get_atlas_data_ext(self.atlas_format)
+            atlas_data_ext = self.atlas_ext or Utils.get_atlas_data_ext(self.atlas_format)
             Utils.save_atlas_data(packed_plist, os.path.join(output_path, "%s%s" % (texture_file_name, atlas_data_ext)),
                 self.atlas_format)
             Utils.save_image(packed_image, os.path.join(output_path, "%s%s" % (texture_file_name, self.texture_format)))

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,7 @@ These color values can reduce artifacts around sprites and removes dark halos at
 
 extrude
 -------
+
 Extrude repeats the sprite's pixels at the border. Sprite's size is not changed.
 
 There are two uses for this:
@@ -137,8 +138,15 @@ There are two uses for this:
 
 atlas_format
 -------
-Choose the texture config format that file will use. Available options "plist" or "json".
+
+Choose the texture config format that file will use. Available options "plist", "json" and "csv". Aditionally, you can use a custom function that will receive a dictionary and a path and handle the format in some custom way.
 The default texture config output format is "plist".
+
+atlas_ext
+-------
+
+Forces the atlas to use this extension regardless of the format.
+If not provided, the atlas will use the default extension for the chosen format.
 
 Contribute
 ==========


### PR DESCRIPTION
Also added an error if the format is invalid and a new property, ``atlas_ext`` in case the user wants to set a custom extension (defaults to ``None`` which, in turn, defaults to the default extension for the ``atlas_format``). This is specially useful when using a function as the "format".